### PR TITLE
Check target before attempting to make

### DIFF
--- a/R/write_makefile.R
+++ b/R/write_makefile.R
@@ -67,7 +67,7 @@ makefile_rules = function(remakefile, targets, add_args){
     dep = dep[dep != "target_name"] # "target_name" is a keyword in remake.
     cat(dep, "\n")
     if("command" %in% names(target) | !is.null(target$knitr)){
-      cat("\tRscript -e \'if (!remake::is_current(\"",
+      cat("\tR -q -e \'if (!remake::is_current(\"",
           name, "\")) remake::make(\"", name, "\", remake_file = \"",
           remakefile, "\"", add_args, ")\'\n", sep = "")
     }

--- a/R/write_makefile.R
+++ b/R/write_makefile.R
@@ -67,7 +67,8 @@ makefile_rules = function(remakefile, targets, add_args){
     dep = dep[dep != "target_name"] # "target_name" is a keyword in remake.
     cat(dep, "\n")
     if("command" %in% names(target) | !is.null(target$knitr)){
-      cat("\tRscript -e \'remake::make(\"", name, "\", remake_file = \"", 
+      cat("\tRscript -e \'if (!remake::is_current(\"",
+          name, "\")) remake::make(\"", name, "\", remake_file = \"",
           remakefile, "\"", add_args, ")\'\n", sep = "")
     }
     cat("\n")


### PR DESCRIPTION
This is much cheaper, because remake needs to check only the current target; the other targets are checked by make itself.